### PR TITLE
DL-5294fix fix warns

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -199,7 +199,7 @@ microservice {
     }
 
     etmp-hod {
-      host = localhost
+      host = "127.0.0.1"
       port = 9926
       environment = ""
       authorization-token = ""

--- a/it/helpers/application/IntegrationApplication.scala
+++ b/it/helpers/application/IntegrationApplication.scala
@@ -29,7 +29,7 @@ trait IntegrationApplication extends GuiceOneServerPerSuite with WireMockConfig 
     .overrides(playBind[HttpClient].to[DefaultHttpClient])
     .configure(
       Map(
-      "application.router" -> "testOnlyDoNotUseInAppConf.Routes",
+      "play.http.router" -> "testOnlyDoNotUseInAppConf.Routes",
       "microservice.metrics.graphite.host" -> "localhost",
       "microservice.metrics.graphite.port" -> 2003,
       "microservice.metrics.graphite.prefix" -> "play.business-customer.",


### PR DESCRIPTION
Fix warns coming from running it tests - deprecated application.router
Suppress waning being generated when running ATs locally - to use simulated external port for etmp instead of localhost
