### PR TITLE
bootstrap-play and play 2.8.15 upgrade

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -12,19 +12,18 @@ object AppDependencies extends TestDependencies {
   val compile: Seq[ModuleID] = Seq(
     ws,
     "uk.gov.hmrc" %% "bootstrap-backend-play-28" % "5.24.0",
-    "uk.gov.hmrc" %% "domain"                    % "6.2.0-play-28",
+    "uk.gov.hmrc" %% "domain"                    % "8.1.0-play-28",
     compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.7.8" cross CrossVersion.full),
-    "com.github.ghik" % "silencer-lib" % "1.7.7" % Provided cross CrossVersion.full
+    "com.github.ghik" % "silencer-lib" % "1.7.8" % Provided cross CrossVersion.full
   )
   
   val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"                   %% "bootstrap-test-play-28"     % "5.24.0"            % scope,
-    "org.pegdown"                   %  "pegdown"                    % "1.6.0"             % scope,
     "com.typesafe.play"             %% "play-test"                  % PlayVersion.current % scope,
-    "org.mockito"                   %  "mockito-core"               % "4.2.0"             % scope,
+    "org.mockito"                   %  "mockito-core"               % "4.5.1"             % scope,
     "org.scalatestplus"             %% "scalatestplus-mockito"      % "1.0.0-M2"          % scope,
     "com.fasterxml.jackson.module"  %% "jackson-module-scala"       % "2.13.3"            % scope,
-    "com.github.tomakehurst"        %  "wiremock-jre8"              % "2.32.0"            % IntegrationTest withSources()
+    "com.github.tomakehurst"        %  "wiremock-jre8"              % "2.33.2"            % IntegrationTest withSources()
   )
 
   def apply() = compile ++ test

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -11,19 +11,19 @@ object AppDependencies extends TestDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     ws,
-    "uk.gov.hmrc" %% "bootstrap-backend-play-28" % "5.18.0",
+    "uk.gov.hmrc" %% "bootstrap-backend-play-28" % "5.24.0",
     "uk.gov.hmrc" %% "domain"                    % "6.2.0-play-28",
-    compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.7.7" cross CrossVersion.full),
+    compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.7.8" cross CrossVersion.full),
     "com.github.ghik" % "silencer-lib" % "1.7.7" % Provided cross CrossVersion.full
   )
   
   val test: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"                   %% "bootstrap-test-play-28"     % "5.18.0"            % scope,
+    "uk.gov.hmrc"                   %% "bootstrap-test-play-28"     % "5.24.0"            % scope,
     "org.pegdown"                   %  "pegdown"                    % "1.6.0"             % scope,
     "com.typesafe.play"             %% "play-test"                  % PlayVersion.current % scope,
     "org.mockito"                   %  "mockito-core"               % "4.2.0"             % scope,
     "org.scalatestplus"             %% "scalatestplus-mockito"      % "1.0.0-M2"          % scope,
-    "com.fasterxml.jackson.module"  %% "jackson-module-scala"       % "2.13.1"            % scope,
+    "com.fasterxml.jackson.module"  %% "jackson-module-scala"       % "2.13.3"            % scope,
     "com.github.tomakehurst"        %  "wiremock-jre8"              % "2.32.0"            % IntegrationTest withSources()
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,8 +7,8 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.15")
 
-addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.9.2")
+addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.9.3")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")


### PR DESCRIPTION
DL-7794 Bootstrap play and play 2.8.15 upgrade

**New feature**

Upgrading to use bootstrap-play 5.24.0 and play 2.8.15. This is to protect against a security vulnerability that has been found in Play, and comes of the back of this [techspace blog](https://confluence.tools.tax.service.gov.uk/pages/viewpage.action?pageId=447906456).

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
